### PR TITLE
Fix empty reference ids

### DIFF
--- a/handler/store_rpc.go
+++ b/handler/store_rpc.go
@@ -241,13 +241,13 @@ func (s *StoreRPCClient) GetTrustAnchorIDs(token *proto.AttestationToken) ([]str
 
 	data, err = json.Marshal(token)
 	if err != nil {
-		return []string{""}, fmt.Errorf("marshaling token: %w", err)
+		return nil, fmt.Errorf("marshaling token: %w", err)
 	}
 
 	err = s.client.Call("Plugin.GetTrustAnchorIDs", data, &resp)
 	if err != nil {
 		err = ParseError(err)
-		return []string{""}, fmt.Errorf("Plugin.GetTrustAnchorIDs RPC call failed: %w", err) // nolint
+		return nil, fmt.Errorf("Plugin.GetTrustAnchorIDs RPC call failed: %w", err) // nolint
 	}
 
 	return resp, nil

--- a/integration-tests/utils/generators.py
+++ b/integration-tests/utils/generators.py
@@ -128,9 +128,11 @@ def generate_evidence(scheme, evidence, nonce, signing, outname):
 
     if scheme == 'psa' and nonce:
         claims_file = f'{GENDIR}/claims/{scheme}.{evidence}.json'
+        # convert nonce from base64url to base64
+        translated_nonce = nonce.replace('-', '+').replace('_', '/')
         update_json(
                 f'data/claims/{scheme}.{evidence}.json',
-                {f'{scheme}-nonce': nonce},
+                {f'{scheme}-nonce': translated_nonce},
                 claims_file,
                 )
     elif scheme == 'cca' and nonce:

--- a/scheme/arm-cca/store_handler.go
+++ b/scheme/arm-cca/store_handler.go
@@ -48,16 +48,16 @@ func (s StoreHandler) SynthKeysFromTrustAnchor(tenantID string, ta *handler.Endo
 func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string, error) {
 	evidence, err := ccatoken.DecodeAndValidateEvidenceFromCBOR(token.Data)
 	if err != nil {
-		return []string{""}, handler.BadEvidence(err)
+		return nil, handler.BadEvidence(err)
 	}
 
 	claims := evidence.PlatformClaims
 	if err != nil {
-		return []string{""}, err
+		return nil, err
 	}
 	taID, err := arm.GetTrustAnchorID(SchemeName, token.TenantId, claims)
 	if err != nil {
-		return []string{""}, err
+		return nil, err
 	}
 
 	return []string{taID}, nil

--- a/scheme/parsec-cca/store_handler.go
+++ b/scheme/parsec-cca/store_handler.go
@@ -43,13 +43,13 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 
 	err := evidence.FromCBOR(token.Data)
 	if err != nil {
-		return []string{""}, handler.BadEvidence(err)
+		return nil, handler.BadEvidence(err)
 	}
 	claims := evidence.Pat.PlatformClaims
 
 	taID, err := arm.GetTrustAnchorID(SchemeName, token.TenantId, claims)
 	if err != nil {
-		return []string{""}, err
+		return nil, err
 	}
 
 	return []string{taID}, nil

--- a/scheme/parsec-tpm/store_handler.go
+++ b/scheme/parsec-tpm/store_handler.go
@@ -42,12 +42,12 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 	var ev tpm.Evidence
 	err := ev.FromCBOR(token.Data)
 	if err != nil {
-		return []string{""}, handler.BadEvidence(err)
+		return nil, handler.BadEvidence(err)
 	}
 
 	kat := ev.Kat
 	if kat == nil {
-		return []string{""}, errors.New("no key attestation token to fetch Key ID")
+		return nil, errors.New("no key attestation token to fetch Key ID")
 	}
 	kid := *kat.KID
 	instance_id := base64.StdEncoding.EncodeToString(kid)

--- a/scheme/psa-iot/store_handler.go
+++ b/scheme/psa-iot/store_handler.go
@@ -38,14 +38,14 @@ func (s StoreHandler) SynthKeysFromTrustAnchor(tenantID string, ta *handler.Endo
 func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string, error) {
 	psaToken, err := psatoken.DecodeAndValidateEvidenceFromCOSE(token.Data)
 	if err != nil {
-		return []string{""}, handler.BadEvidence(err)
+		return nil, handler.BadEvidence(err)
 	}
 
 	claims := psaToken.Claims
 
 	taID, err := arm.GetTrustAnchorID(SchemeName, token.TenantId, claims)
 	if err != nil {
-		return []string{""}, err
+		return nil, err
 	}
 
 	return []string{taID}, nil

--- a/scheme/tpm-enacttrust/store_handler.go
+++ b/scheme/tpm-enacttrust/store_handler.go
@@ -43,7 +43,7 @@ func (s StoreHandler) GetTrustAnchorIDs(token *proto.AttestationToken) ([]string
 			strings.Join(EvidenceMediaTypes, ", "),
 			token.MediaType,
 		)
-		return []string{""}, err
+		return nil, err
 	}
 
 	var decoded Token

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -442,6 +442,11 @@ func (o *GRPC) GetAttestation(
 
 	var multEndorsements []string
 	for _, refvalID := range appraisal.EvidenceContext.ReferenceIds {
+		// Skip empty reference IDs (can occur when no software components are provisioned)
+		if refvalID == "" {
+			o.logger.Debugw("skipping empty reference ID", "refvalID", refvalID)
+			continue
+		}
 
 		endorsements, err := o.EnStore.Get(refvalID)
 		if err != nil && !errors.Is(err, kvstore.ErrKeyNotFound) {

--- a/vts/trustedservices/trustedservices_grpc.go
+++ b/vts/trustedservices/trustedservices_grpc.go
@@ -428,21 +428,13 @@ func (o *GRPC) GetAttestation(
 		return o.finalize(appraisal, err)
 	}
 
-	// Filter out empty reference IDs (can occur when no software components are provisioned)
-	filteredReferenceIDs := make([]string, 0, len(referenceIDs))
-	for _, refID := range referenceIDs {
-		if refID != "" {
-			filteredReferenceIDs = append(filteredReferenceIDs, refID)
-		}
-	}
-
 	appraisal.EvidenceContext.Evidence, err = structpb.NewStruct(claims)
 	if err != nil {
 		err = fmt.Errorf("unserializable claims in result: %w", err)
 		return o.finalize(appraisal, err)
 	}
 
-	appraisal.EvidenceContext.ReferenceIds = filteredReferenceIDs
+	appraisal.EvidenceContext.ReferenceIds = referenceIDs
 
 	o.logger.Debugw("constructed evidence context",
 		"software-id", appraisal.EvidenceContext.ReferenceIds,
@@ -509,12 +501,12 @@ func (c *GRPC) getTrustAnchors(id []string) ([]string, error) {
 	for _, taID := range id {
 		values, err := c.TaStore.Get(taID)
 		if err != nil {
-			return []string{""}, err
+			return nil, err
 		}
 
 		// For now, Veraison schemes only support one trust anchor per trustAnchorID
 		if len(values) != 1 {
-			return []string{""}, fmt.Errorf("found %d trust anchors, want 1", len(values))
+			return nil, fmt.Errorf("found %d trust anchors, want 1", len(values))
 		}
 		taValues = append(taValues, values[0])
 	}


### PR DESCRIPTION
## Summary by Sourcery

Return nil slice instead of slice with empty string on error paths in trust anchor ID retrieval methods across various schemes and RPC handler, and fix nonce encoding in integration test generator.

Bug Fixes:
- Return nil slice instead of slice containing empty string for error cases in GetTrustAnchorIDs and related methods

Tests:
- Convert nonce from base64url to base64 in integration test evidence generator